### PR TITLE
fix: remove no-jest-import rule

### DIFF
--- a/src/rules/jest.js
+++ b/src/rules/jest.js
@@ -32,7 +32,6 @@ module.exports = {
         'jest/no-if': 'warn',
         'jest/no-interpolation-in-snapshots': 'off',
         'jest/no-jasmine-globals': 'error',
-        'jest/no-jest-import': 'warn',
         'jest/no-large-snapshots': 'off',
         'jest/no-mocks-import': 'error',
         'jest/no-restricted-matchers': [


### PR DESCRIPTION
no longer supported from eslint-plugin-jest >= 27