### PR TITLE
feat: rule @typescript-eslint/consistent-type-imports warn

### DIFF
--- a/src/rules/typescript.js
+++ b/src/rules/typescript.js
@@ -182,6 +182,11 @@ const eslintConfig = {
                 '@typescript-eslint/unified-signatures': 'off',
                 '@typescript-eslint/prefer-ts-expect-error': 'warn',
                 'no-undef': 'off',
+                '@typescript-eslint/consistent-type-imports': ['warn', {
+                    prefer: 'type-imports',
+                    fixStyle: 'inline-type-imports',
+                    disallowTypeAnnotations: false,
+                }],
             },
         },
     ],


### PR DESCRIPTION
BREAKING CHANGE: omitting type specifier in import will throw warning